### PR TITLE
Fix splash screen logo asset path

### DIFF
--- a/lib/screens/splash/splash_screen.dart
+++ b/lib/screens/splash/splash_screen.dart
@@ -77,7 +77,7 @@ class _SplashScreenState extends State<SplashScreen>
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Image.asset('assets/images/logo.png', width: 120, height: 120),
+              Image.asset('assets/icon.png', width: 120, height: 120),
               const SizedBox(height: 24),
               const Text(
                 'SettleEase',


### PR DESCRIPTION
## Summary
- point splash screen to the correct app icon

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42dfc13f4832ca302d9d71afc1756